### PR TITLE
[exemple local] No relink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ api_analytics_secrets.json
 
 /apache-solr
 
+*.makelock
 /.tmp
 
 /scripts/release_summary.md

--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -117,6 +117,8 @@ if  ! $(_in "-packages" $@) && ( $(_in "+packages" $@) || $(_in "+base" $@) || $
         fi
         echo ""
     done
+    echo "$filepath" > packages.makelock
+    cat "$filepath" > "$filepath.makelock"
 fi
 
 

--- a/scripts/install_zds.sh
+++ b/scripts/install_zds.sh
@@ -338,6 +338,7 @@ if  ! $(_in "-tex-local" $@) && ( $(_in "+tex-local" $@) || $(_in "+full" $@) );
     cd $BASE_REPO
 
     if [ -d $REPO ]; then # remove previous version of the template
+        rm -rf $BASE_REPO
         rm -rf $REPO
     fi
 


### PR DESCRIPTION
Petit exemple personnel à but pédagogique de rendre un script *complexe* existant qui relink à ne plus relink (c'est la première chose à 42 qu'on est encouragé à apprendre).

https://github.com/GlaceCoding/zds-site/blob/02cdb7aff7b890cf7d4cbf300985a2b03af65c80/Makefile#L19-L21

Prenons une tâche, par exemple : "il-packages" (pour *il = install linux*), on constate que je redirige le fichier vers le fichier `$(PACKAGES_PATH).makelock`, le contenu n'est pas important, il peut-être vide ou plein, la seule importance c'est le fait qu'il existe ou non:
 - S'il n'existe pas: le script de la tâche sera lancé ;
 - S'il existe: le contenu de `$(PACKAGES_PATH)`, mis en argument de la tâche, sera vérifié par le Makefile, si un changement est détecté (même de simples espaces ajoutés à la fin), la tâche sera relancé, sinon un message "rien à faire" apparaitra.

La force de cette fonctionnalité du Makefile:
 - Gain de temps, ne relance pas les commandes inutilement (si les fichiers de prérequis ne changent pas) ;
 - Permet de rendre un script d'installation polyvalent et servir d'udapter si un changement est détecté ;
 - La règle d'installation peut-être ajouté à la règle d’exécution sans crainte.

En soit il n'y a pas vraiment de contrainte car [si le fichier de prérequis (ici script/dependencies/ubuntu.txt, pout la tâche packages)](https://github.com/GlaceCoding/zds-site/blob/02cdb7aff7b890cf7d4cbf300985a2b03af65c80/scripts/dependencies/ubuntu.txt) ne changent pas, on a rien à installer. Si un changement est détecté on choisi de réinstaller ce qui correspond au fichier de prérequis ou à la globalité.